### PR TITLE
Fix link for Rev.7 in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,7 +12,7 @@ With Micro Journal, I'm exploring how to build such a device from the ground up.
 | ---------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------ |
 | 2025-09-26 | **[AlphaSmart Neo2 Desktop TypeWriter](/micro-journal-neo2/readme.md)**     | <img src="./micro-journal-neo2/images/001.jpg" width="200">            |
 | 2025-07-26 | **[Rev.4 Revamp](/micro-journal-rev-4-revamp/readme.md)**     | <img src="./micro-journal-rev-4-revamp/images/001.png" width="200">            |
-| 2025-01-30 | **[Rev.7](/micro-journal-rev-2-revamp/readme.md)**            | <img src="./micro-journal-rev-7-e-ink/images/home.jpg" width="200">            |
+| 2025-01-30 | **[Rev.7](/micro-journal-rev-7-e-ink/readme.md)**            | <img src="./micro-journal-rev-7-e-ink/images/home.jpg" width="200">            |
 | 2024-09-17 | **[Rev.2 Revamp](/micro-journal-rev-2-revamp/readme.md)**     | <img src="./micro-journal-rev-2-revamp/images/home_001.jpg" width="200">       |
 | 2024-06-13 | **[Rev.6](/micro-journal-rev-6-one-piece/readme.md)**         | <img src="./micro-journal-rev-6-one-piece/images/001.png" width="200">         |
 | 2024-04-18 | **[Rev.5](/micro-journal-rev-5-esp32-usbhost/readme.md)**     | <img src="./micro-journal-rev-5-esp32-usbhost/images/001.jpg" width="200">     |


### PR DESCRIPTION
This PR fixes an incorrect link in the projects table. The Rev.7 entry was pointing to the Rev.2 Revamp directory instead of its own folder.

### Details

**Before:**

```
[Rev.7](/micro-journal-rev-2-revamp/readme.md)
```

**After:**
```
[Rev.7](/micro-journal-rev-7-e-ink/readme.md)
```

**Reason for change**

The incorrect link caused confusion by redirecting to the Rev.2 documentation instead of Rev.7. This update ensures that the Rev.7 entry correctly links to its corresponding `micro-journal-rev-7-e-ink` directory.